### PR TITLE
Use LleidaNET HTTPS url

### DIFF
--- a/lleida_net/sms/api.py
+++ b/lleida_net/sms/api.py
@@ -8,7 +8,7 @@ from munch import Munch
 from ..click_sign import serializers
 
 api_url_envs = {
-        'prod':'http://api.lleida.net/sms/v2/',
+    'prod':'https://api.lleida.net/sms/v2/',
     # 'staging': None,
 }
 


### PR DESCRIPTION
We received an email from LleidaNET and this PR fixes a deprecated URL :)

> **Enforce HTTPS**
> 
> Dear customer,
> 
> To improve the security of our services, we will block access to all our APIs and web services via HTTP (without TLS encryption) from 1 September 2023. Please note that all services offered by Lleida.net are available via HTTPS, so you must change http:// to https:// in existing integrations before this date.
